### PR TITLE
Fix FTBFS - Release tarballs have moved to GitHub

### DIFF
--- a/awesome.spec
+++ b/awesome.spec
@@ -10,8 +10,8 @@ Summary:	Highly configurable, framework window manager for X. Fast, light and ex
 Group:		User Interface/Desktops
 # common/buffer.[ch]: BSD
 License:	GPLv2+ and BSD
-URL:		http://awesome.naquadah.org
-Source0:	http://awesome.naquadah.org/download/%{name}-%{version}.tar.xz
+URL:		https://awesomewm.org
+Source0:	https://github.com/awesomeWM/awesome-releases/raw/master/%{name}-%{version}.tar.xz
 Patch0:		awesome-3.5.9-lua-generic.patch
 Patch1:		awesome-3.5.5-use-vi-instead-of-nano.patch
 Patch100:	awesome-3.5.5-qubes-prefix.patch


### PR DESCRIPTION
Fix failure to build from source. `make get-sources` fails when the source tree is completely clean, because the tarball can't be downloaded from the old location:

```
-> Updating sources for desktop-linux-awesome...
--> Fetching from https://github.com/QubesOS/qubes-desktop-linux-awesome.git release3.2...
--> Verifying tags...
--> Merging...

--> Downloading additional sources for desktop-linux-awesome...
Makefile:36: recipe for target 'awesome-3.5.9.tar.xz' failed
make[1]: *** [awesome-3.5.9.tar.xz] Error 8
Makefile:189: recipe for target 'desktop-linux-awesome.get-sources-extra' failed
make: *** [desktop-linux-awesome.get-sources-extra] Error 2
```

From the `qubes-builder` directory, you can test this quickly with the following command:
```sh
rm -f qubes-src/desktop-linux-awesome/awesome-3.5.9.tar.xz && \
make get-sources COMPONENTS=desktop-linux-awesome
```

I did my testing against the `release3.2` branch, but I think this fix should be applied to *both* the `release3.2` branch *and* the `master` branch.