### PR TITLE
Qubes 4.0 menu support

### DIFF
--- a/awesome.spec
+++ b/awesome.spec
@@ -140,8 +140,8 @@ desktop-file-validate %{buildroot}%{_datadir}/xsessions/%{name}.desktop
 
 %changelog
 * Tue Dec 12 2017 David Hobach <tripleh@hackingthe.net> - 3.5.9-4
-- added support of the awesome menu for Qubes 4.0
-- added an optional dom0 menu
+- added menu support for Qubes 4.0
+- added optional support for awesome-specific menu entries
 
 * Sat Aug 12 2017 David Hobach <tripleh@hackingthe.net> - 3.5.9-4
 - fixed https://github.com/QubesOS/qubes-issues/issues/2780

--- a/awesome.spec
+++ b/awesome.spec
@@ -139,6 +139,10 @@ desktop-file-validate %{buildroot}%{_datadir}/xsessions/%{name}.desktop
 
 
 %changelog
+* Tue Dec 12 2017 David Hobach <tripleh@hackingthe.net> - 3.5.9-4
+- added support of the awesome menu for Qubes 4.0
+- added an optional dom0 menu
+
 * Sat Aug 12 2017 David Hobach <tripleh@hackingthe.net> - 3.5.9-4
 - fixed https://github.com/QubesOS/qubes-issues/issues/2780
 - added patch to make the border colors work with Qubes 4.0rc1

--- a/qubes.lua.in
+++ b/qubes.lua.in
@@ -199,6 +199,11 @@ function qubes.make_menu(filter, menuitemfunc)
     if filter ~= nil then menufunc = filter(vmname) end
     local menuitemfunc = menuitemfunc or qubes.make_menuitem
 
+    --add the dom0 menu
+    --this is enitrely optional and enables users to create xdg desktop files at the below file path in order to populate the dom0 menu
+    --it will remain invisible until that directory is accessible
+    table.insert(menu, qubes.make_vm_menu('Dom0', nil, HOME .. '/.config/awesome/dom0-menu/', '/usr/share/icons/hicolor/16x16/apps/qubes-logo-icon.png'))
+
     --add the VM application menus
     for vmname in io.popen([[python -c "
 from qubesadmin import Qubes

--- a/qubes.lua.in
+++ b/qubes.lua.in
@@ -170,11 +170,6 @@ function qubes.get_colour_focus(c)
     return get_colour_by_state(c, 'qubes_label_color_focus')
 end
 
-function qubes.manager_menuitem()
-    return {'Qubes Manager', 'qubes-manager',
-        '/usr/share/icons/hicolor/16x16/apps/qubes-logo-icon.png'}
-end
-
 function qubes.make_menuitem(vm, program)
     return {program.Name, program.cmdline, program.icon_path}
 end
@@ -223,7 +218,6 @@ end
 
 function qubes.make_menu()
     local menu = qubes.make_menu_with_filter()
-    table.insert(menu, qubes.manager_menuitem())
     return menu
 end
 

--- a/qubes.lua.in
+++ b/qubes.lua.in
@@ -161,7 +161,7 @@ function qubes.get_colour_focus(c)
     return get_colour_by_state(c, 'qubes_label_color_focus')
 end
 
-function is_accessible(path)
+local function is_accessible(path)
     return os.rename(path, path) and true or false
 end
 
@@ -172,49 +172,71 @@ function qubes.make_menuitem(vm, program)
     return {program.Name, program.cmdline, appicon}
 end
 
---all parameters except for vmname are optional
-function qubes.make_vm_menu(vmname, menuitemfunc, vmapps, vmicon)
+--menuitemfunc & vmicon are optional parameters
+function qubes.make_vm_menu(vmname, desktop_files, menuitemfunc, vmicon)
     local menu = {}
-    local vmapps = vmapps or HOME .. '/.local/share/qubes-appmenus/' .. vmname .. '/apps/'
     local menuitemfunc = menuitemfunc or qubes.make_menuitem
     local vmicon = vmicon or '/var/lib/qubes/appvms/' .. vmname .. '/icon.png'
 
-    if not is_accessible(vmapps) then return nil end
+    if vmname == nil then return nil end
 
-    for _, program in ipairs(menubar.utils.parse_dir(vmapps)) do
-        local menuitem = menuitemfunc(vmname, program)
-        if menuitem ~= nil then table.insert(menu, menuitem) end
+    for _, dfile in pairs(desktop_files) do
+        if dfile ~= nil then
+            local dpath = HOME .. '/.local/share/applications/' .. dfile
+            if is_accessible(dpath) then
+                local menuitem = menuitemfunc(vmname, menubar.utils.parse(dpath))
+                if menuitem ~= nil then table.insert(menu, menuitem) end
+            end
+        end
     end
 
-    --NOTE: awesome will not display menu entries with invalid icon paths
-    return {vmname, menu, vmicon}
+    if next(menu) == nil then
+        return nil
+    else
+        --NOTE: awesome will not display menu entries with invalid icon paths
+        return {vmname, menu, vmicon}
+    end
+end
+
+--filter, menuitemfunc & menuicon are optional parameters
+--menu is an output parameter passed by reference
+local function parse_menufile_dir(menu, menufile_dir, filter, menuitemfunc, menuicon)
+    local menufunc = qubes.make_vm_menu
+    local menuitemfunc = menuitemfunc or qubes.make_menuitem
+    
+    --since awesome only supports .desktop files, but Qubes also uses .menu files, we "parse" the .menu files with sed to find the relevant .desktop files for a VM
+    local last_desktop_files = {}
+    local last_name = nil
+    local cmd=[[bash -c 'for file in ]] .. menufile_dir .. [[/*.menu; do sort -b "$file"; done']]
+    --the sorting is needed to support arbitrary ordering of the xml tags
+    for line in io.popen(cmd):lines() do
+        local nmatch = string.match(line, '<Name>(.*)</Name>')
+        if nmatch ~= nil and nmatch ~= "Applications" then
+                --name of the 1st level menu:
+                last_name = string.match(nmatch,'^(.*)-vm$') or nmatch
+                if last_name ~= nil then table.insert(menu, menufunc(last_name, last_desktop_files, menuitemfunc, menuicon)) end
+                if filter ~= nil then menufunc = filter(last_name) end
+                last_desktop_files = {}
+        else
+                --potential desktop file:
+                local fmatch = string.match(line, '<Filename>(.*%.desktop)</Filename>')
+                if fmatch ~= nil then table.insert(last_desktop_files, fmatch) end
+        end
+     end
 end
 
 --filter & menuitemfunc are optional parameters
 function qubes.make_menu(filter, menuitemfunc)
     local menu = {}
 
-    --set reasonable defaults
-    local menufunc = qubes.make_vm_menu
-    if filter ~= nil then menufunc = filter(vmname) end
-    local menuitemfunc = menuitemfunc or qubes.make_menuitem
-
-    --add the dom0 menu
-    --this is enitrely optional and enables users to create xdg desktop files at the below file path in order to populate the dom0 menu
-    --it will remain invisible until that directory is accessible
-    table.insert(menu, qubes.make_vm_menu('Dom0', nil, HOME .. '/.config/awesome/dom0-menu/', '/usr/share/icons/hicolor/16x16/apps/qubes-logo-icon.png'))
+    --add the awesome-specific menus
+    --this is enitrely optional and enables users to create xdg menu files at the below file path in order to populate the first menu entries (e.g. for awesome-specific control tools)
+    --the desktop files referenced from the .menu files must be stored at ~/.local/share/applications/
+    --it will remain invisible until that directory has .menu files referencing valid .desktop files
+    parse_menufile_dir(menu, '~/.config/awesome/xdg-menu', filter, menuitemfunc, '/usr/share/icons/hicolor/16x16/apps/qubes-logo-icon.png')
 
     --add the VM application menus
-    for vmname in io.popen([[python -c "
-from qubesadmin import Qubes
-app = Qubes()
-ret = []
-for vm in app.domains: ret.append(vm.name)
-ret.sort(key=lambda i: i.lower())
-print('\n'.join(ret))
-"]]):lines() do
-        table.insert(menu, menufunc(vmname, menuitemfunc))
-    end
+    parse_menufile_dir(menu, '~/.config/menus/applications-merged', filter, menuitemfunc)
 
     return menu
 end

--- a/qubes.lua.in
+++ b/qubes.lua.in
@@ -80,17 +80,6 @@ end
 
 -- end of codelifting
 
-local function parse_desktop_file(desktop)
-    local entry = {}
-    for line in io.lines(desktop) do
-        key, value = line:match('^(%w+)%s*=%s*(.*)$')
-        if key ~= nil then
-            entry[key] = value
-        end
-    end
-    return entry
-end
-
 local function ensure_min_luminance(colour, minLuminance)
     local r, g, b = color.parse_color(colour)
 

--- a/qubes.lua.in
+++ b/qubes.lua.in
@@ -19,6 +19,8 @@ local menubar = require('menubar')
 
 local qubes = {}
 
+local HOME = os.getenv("HOME")
+
 -- the following three functions are lifted from
 --  /usr/lib64/python2.7/colorsys.py
 
@@ -170,50 +172,45 @@ function qubes.make_menuitem(vm, program)
     return {program.Name, program.cmdline, appicon}
 end
 
-function qubes.make_vm_menu(vm, menuitemfunc)
+--all parameters except for vmname are optional
+function qubes.make_vm_menu(vmname, menuitemfunc, vmapps, vmicon)
     local menu = {}
+    local vmapps = vmapps or HOME .. '/.local/share/qubes-appmenus/' .. vmname .. '/apps/'
+    local menuitemfunc = menuitemfunc or qubes.make_menuitem
+    local vmicon = vmicon or '/var/lib/qubes/appvms/' .. vmname .. '/icon.png'
 
-    for _, program in ipairs(menubar.utils.parse_dir(vm.path .. '/apps')) do
-        local menuitem = menuitemfunc(vm, program)
-        if menuitem ~= nil then
-            table.insert(menu, menuitem)
-        end
+    if not is_accessible(vmapps) then return nil end
+
+    for _, program in ipairs(menubar.utils.parse_dir(vmapps)) do
+        local menuitem = menuitemfunc(vmname, program)
+        if menuitem ~= nil then table.insert(menu, menuitem) end
     end
-    return {vm.name, menu, vm.path .. '/icon.png'}
+
+    --NOTE: awesome will not display menu entries with invalid icon paths
+    return {vmname, menu, vmicon}
 end
 
-function qubes.make_menu_with_filter(filter, menuitemfunc)
+--filter & menuitemfunc are optional parameters
+function qubes.make_menu(filter, menuitemfunc)
     local menu = {}
-    for line in io.popen([[python -c "
-import os.path
-import qubes.qubes
-qvmc = qubes.qubes.QubesVmCollection()
-qvmc.lock_db_for_reading()
-qvmc.load()
-qvmc.unlock_db()
-print('\n'.join('{} {} {}'.format(vm.name, vm.type, vm.dir_path)
-    for vm in sorted(qvmc.values(), key=lambda vm: vm.name)
-    if os.path.isdir(vm.dir_path)))
+
+    --set reasonable defaults
+    local menufunc = qubes.make_vm_menu
+    if filter ~= nil then menufunc = filter(vmname) end
+    local menuitemfunc = menuitemfunc or qubes.make_menuitem
+
+    --add the VM application menus
+    for vmname in io.popen([[python -c "
+from qubesadmin import Qubes
+app = Qubes()
+ret = []
+for vm in app.domains: ret.append(vm.name)
+ret.sort(key=lambda i: i.lower())
+print('\n'.join(ret))
 "]]):lines() do
-        local vm = {}
-        vm.name, vm.type, vm.path = line:match('^(.+) (.+) (.+)$')
-        io.stderr:write('line=' .. line .. '\n')
-        if menuitemfunc == nil then
-            menuitemfunc = qubes.make_menuitem
-        end
-        local menufunc = qubes.make_vm_menu
-        if filter ~= nil then
-            menufunc = filter(vm)
-        end
-        if menufunc ~= nil then
-            table.insert(menu, menufunc(vm, menuitemfunc))
-        end
+        table.insert(menu, menufunc(vmname, menuitemfunc))
     end
-    return menu
-end
 
-function qubes.make_menu()
-    local menu = qubes.make_menu_with_filter()
     return menu
 end
 

--- a/qubes.lua.in
+++ b/qubes.lua.in
@@ -159,8 +159,15 @@ function qubes.get_colour_focus(c)
     return get_colour_by_state(c, 'qubes_label_color_focus')
 end
 
+function is_accessible(path)
+    return os.rename(path, path) and true or false
+end
+
 function qubes.make_menuitem(vm, program)
-    return {program.Name, program.cmdline, program.icon_path}
+    local appicon = program.icon_path
+    if not is_accessible(appicon) then appicon = nil end
+
+    return {program.Name, program.cmdline, appicon}
 end
 
 function qubes.make_vm_menu(vm, menuitemfunc)


### PR DESCRIPTION
This PR

- makes the application menu work again in Qubes 4.0. The python code from 3.2 didn't work anymore as the Qubes API changed.

- adds an optional awesome-specific application menu which can be created with xdg menu files at ~/.config/awesome/xdg-menu/

- does some cleanup

Further details can be found in the respective commit messages.

I attempted to keep the changes of PR #4  alive, but the function parameters had to be changed unfortunately due to the Qubes API changes.