### PR TITLE
handle leftover menu files

### DIFF
--- a/qubes.lua.in
+++ b/qubes.lua.in
@@ -178,6 +178,7 @@ function qubes.set_name(c)
 end
 
 local function is_accessible(path)
+    if path == nil then return false end
     return os.rename(path, path) and true or false
 end
 


### PR DESCRIPTION
Leftover menu files from removed VMs cause a nil path which will
crash awesome. Ignore those.